### PR TITLE
chore: migrate to nova module naming across workspace

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -27,10 +27,10 @@ import (
 	"golang.org/x/net/http2/h2c"
 	"google.golang.org/grpc"
 
-	"birpc/internal/adapters"
-	"birpc/internal/gen/store/v1/storev1connect"
-	"birpc/service/model"
-	"birpc/service/storage"
+	"nova/internal/adapters"
+	"nova/internal/gen/store/v1/storev1connect"
+	"nova/service/model"
+	"nova/service/storage"
 )
 
 /*****************************************************************************************************************/

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module birpc
+module nova
 
 go 1.22.4
 

--- a/internal/gen/store/v1/storev1connect/store.connect.go
+++ b/internal/gen/store/v1/storev1connect/store.connect.go
@@ -13,7 +13,7 @@
 package storev1connect
 
 import (
-	v1 "birpc/internal/gen/store/v1"
+	v1 "nova/internal/gen/store/v1"
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"

--- a/service/storage/jpeg.go
+++ b/service/storage/jpeg.go
@@ -18,9 +18,9 @@ import (
 	"strings"
 	"time"
 
-	pb "birpc/internal/gen/store/v1"
-	"birpc/internal/middleware"
-	"birpc/internal/stores"
+	pb "nova/internal/gen/store/v1"
+	"nova/internal/middleware"
+	"nova/internal/stores"
 
 	cloud "cloud.google.com/go/storage"
 	"connectrpc.com/connect"

--- a/service/storage/server.go
+++ b/service/storage/server.go
@@ -14,7 +14,7 @@ import (
 	"context"
 	"fmt"
 
-	pb "birpc/internal/gen/store/v1/storev1connect"
+	pb "nova/internal/gen/store/v1/storev1connect"
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/storage"
@@ -22,7 +22,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"birpc/internal/stores"
+	"nova/internal/stores"
 )
 
 /*****************************************************************************************************************/

--- a/service/storage/tiff.go
+++ b/service/storage/tiff.go
@@ -17,9 +17,9 @@ import (
 	"strings"
 	"time"
 
-	pb "birpc/internal/gen/store/v1"
-	"birpc/internal/middleware"
-	"birpc/internal/stores"
+	pb "nova/internal/gen/store/v1"
+	"nova/internal/middleware"
+	"nova/internal/stores"
 
 	cloud "cloud.google.com/go/storage"
 	"connectrpc.com/connect"


### PR DESCRIPTION
chore: migrate to nova module naming across workspace