### PR TITLE
chore: bump @observerly/iris => v0.41.0 across workspace in @observerly/nova

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module nova
 
-go 1.22.4
+go 1.23.2
+
+toolchain go1.23.3
 
 require (
 	ariga.io/atlas-provider-gorm v0.5.0
@@ -12,7 +14,7 @@ require (
 	firebase.google.com/go/v4 v4.14.1
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/observerly/iris v0.35.0
+	github.com/observerly/iris v0.41.0
 	github.com/rs/zerolog v1.33.0
 	golang.org/x/image v0.20.0
 	golang.org/x/net v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/microsoft/go-mssqldb v1.7.2 h1:CHkFJiObW7ItKTJfHo1QX7QBBD1iV+mn1eOyRP
 github.com/microsoft/go-mssqldb v1.7.2/go.mod h1:kOvZKUdrhhFQmxLZqbwUV0rHkNkZpthMITIb2Ko1IoA=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/montanaflynn/stats v0.7.0/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
-github.com/observerly/iris v0.35.0 h1:SBzIeD4vGk955GfhQGkCdSGX+S1H4Wn00UD045nzg9k=
-github.com/observerly/iris v0.35.0/go.mod h1:umxMm/MDEsIivLF71qnhi3PCMt6NwSlusCb2u8Xx8DQ=
+github.com/observerly/iris v0.41.0 h1:2578R93bDQRwwYS7jVxdEkPrM3QUthMyXgTeXkXXtjY=
+github.com/observerly/iris v0.41.0/go.mod h1:umxMm/MDEsIivLF71qnhi3PCMt6NwSlusCb2u8Xx8DQ=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=


### PR DESCRIPTION
chore: bump @observerly/iris => v0.41.0 across workspace in @observerly/nova